### PR TITLE
fixing shell script name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ all the servers in the DB
 ## Go with Docker
 
 ``` bash
-./run-docker.sh
+./docker-run.sh
 # login at localhost:8080 with admin/zenboot
 mkdir -p zenboot-scripts/mytest/scripts
 mkdir -p zenboot-scripts/mytest/plugins


### PR DESCRIPTION
I've noticed that repository has `docker-run.sh` file, but documentation in `README.md` says that we should use `run-docker.sh` file, which doesn't exist in the repository. This PR fixes shell script name in the `README.md` file.

I see build on CI is broken due to some openssl issues. My change couldn't break it as I modified just `README.md` file. I think some Travis configuration update is required. :-)