### PR TITLE
execution zone groovy library directory

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -75,3 +75,11 @@ grails.war.copyToWebApp = { args ->
         include(name: "zenboot-scripts/**")
     }
 }
+
+forkConfig = [maxMemory: 1024, minMemory: 64, debug: false, maxPerm: 256]
+grails.project.fork = [
+        test: forkConfig, // configure settings for the test-app JVM
+        run: forkConfig, // configure settings for the run-app JVM
+        war: forkConfig, // configure settings for the run-war JVM
+        console: forkConfig // configure settings for the Swing console JVM
+]

--- a/grails-app/domain/org/zenboot/portal/processing/Scriptlet.groovy
+++ b/grails-app/domain/org/zenboot/portal/processing/Scriptlet.groovy
@@ -6,7 +6,7 @@ import org.apache.log4j.WriterAppender
 import org.zenboot.portal.ProcessListener
 import org.zenboot.portal.processing.Processable.ProcessState
 
-/**  A Scriptlet is a Domai-class and represents one Run of a
+/**  A Scriptlet is a Domain-class and represents one Run of a
   *  specific Script. It stores all all related stuff in the DB
   *  and also has (unfortunately) execution-logic
   */

--- a/grails-app/services/org/zenboot/portal/processing/ExecutionService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/ExecutionService.groovy
@@ -1,6 +1,7 @@
 package org.zenboot.portal.processing
 
 import org.springframework.context.ApplicationListener
+import org.zenboot.portal.processing.groovy.GroovyScriptUtil
 import org.zenboot.portal.ProcessHandler
 import org.zenboot.portal.processing.converter.ParameterConverter
 import org.zenboot.portal.processing.converter.ParameterConverterMap
@@ -101,8 +102,7 @@ class ExecutionService {
   }
 
   private Object createObjectFromGroovy(File pluginFile, Processable processable) {
-    GroovyClassLoader gcl = new GroovyClassLoader(this.class.classLoader)
-    Class clazz = gcl.parseClass(pluginFile)
+    Class clazz = GroovyScriptUtil.parseGroovyScript(pluginFile)
 
     def plugin = clazz.newInstance()
     def properties = plugin.metaClass.properties*.name

--- a/src/groovy/org/zenboot/portal/processing/groovy/GroovyScriptUtil.groovy
+++ b/src/groovy/org/zenboot/portal/processing/groovy/GroovyScriptUtil.groovy
@@ -1,0 +1,24 @@
+package org.zenboot.portal.processing.groovy
+
+import java.nio.file.Paths
+
+/**
+ * in a perfect world, this would be a service, but ScriptletAnnotationReader
+ * is instantiated via new, and so cannot use services
+ */
+class GroovyScriptUtil {
+    /**
+     * parse a groovy script from the script stack into a class
+     *
+     * adds the "lib" directory from the execution zone to the class path
+     * of the script to facilitate code reuse in scripts
+     *
+     * this assumes the current execution zone structure without substructure
+     */
+    public static Class parseGroovyScript(File script) {
+        GroovyClassLoader gcl = new GroovyClassLoader(GroovyScriptUtil.classLoader)
+        def libPath = Paths.get(script.getParent(), "../../lib").toAbsolutePath().normalize()
+        gcl.addClasspath(libPath.toString() + "/")
+        gcl.parseClass(script)
+    }
+}

--- a/src/groovy/org/zenboot/portal/processing/meta/ScriptletAnnotationReader.groovy
+++ b/src/groovy/org/zenboot/portal/processing/meta/ScriptletAnnotationReader.groovy
@@ -1,6 +1,7 @@
 package org.zenboot.portal.processing.meta
 
 import groovy.text.SimpleTemplateEngine
+import org.zenboot.portal.processing.groovy.GroovyScriptUtil
 
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -48,8 +49,7 @@ class ScriptletAnnotationReader {
 
     private Class getScriptletClass(File script) {
       if (script.getName().split(/\./)[-1] == "groovy") {
-        GroovyClassLoader gcl = new GroovyClassLoader(this.class.classLoader)
-        return gcl.parseClass(script)
+          return GroovyScriptUtil.parseGroovyScript(script)
       } else {
         Class scriptletClass
         Script groovyScript = this.getGroovyScript(script)


### PR DESCRIPTION
When parsing a groovy script from the execution zone, put the `lib` directory of the execution zone on the classpath. That way groovy scripts can share code not only via symlinking or calling each other, but via imports, too.

It should also be possible to include libraries via jar file in the lib directory, although this was not tested.