### PR TITLE
Feature/show all code in script stack with one button

### DIFF
--- a/grails-app/views/executionZone/_flowElementDetails.gsp
+++ b/grails-app/views/executionZone/_flowElementDetails.gsp
@@ -1,7 +1,9 @@
 <strong>
 	${element.file.name}
 </strong>
-<a class="zb-tooltip" onclick="javascript:$('#${element.file.name.replace(".","_")}_text').slideToggle()" title="${message(code:'scriptletBatch.button.showCode', default:'Show Code')}">
+<a class="zb-tooltip"
+	onclick="javascript:$('#${element.file.name.replace('.','_')}_text').slideToggle();"
+	title="${message(code:'scriptletBatch.button.showCode', default:'Show Code')}">
 	<i class="icon-eye-close"></i>
 </a>
 <g:if test="${type}">
@@ -25,4 +27,4 @@
 	</tr>
 </table>
 
-<pre id="${element.file.name.replace(".","_")}_text" style="display: none;">${element.file.text}</pre>
+<pre id="${element.file.name.replace('.','_')}_text" style="display: none;">${element.file.text}</pre>

--- a/grails-app/views/executionZone/_scriptDirs.gsp
+++ b/grails-app/views/executionZone/_scriptDirs.gsp
@@ -6,10 +6,16 @@
     <i class="icon-book"></i>
   </g:remoteLink>
   <g:remoteLink action="ajaxGetFlowChart" params="[scriptDir:scriptDir,execId:execId]" update="scriptdir-${i}_flow_${type}"
-                before="if (!zenboot.prepareAjaxLoading('scriptdir-${i}_flow_${type}', 'scriptdir-${i}_spinner_${type}')) return false"
-                after="zenboot.finalizeAjaxLoading('scriptdir-${i}_flow_${type}', 'scriptdir-${i}_spinner_${type}');" asynchronous="false">
+                before="\$(this).parent().find('.toggle-all-code').toggle(); if (!zenboot.prepareAjaxLoading('scriptdir-${i}_flow_${type}', 'scriptdir-${i}_spinner_${type}')) return false"
+                after="zenboot.finalizeAjaxLoading('scriptdir-${i}_flow_${type}', 'scriptdir-${i}_spinner_${type}');"
+                asynchronous="false">
     <i class="icon-search"></i>
   </g:remoteLink>
+  <a class="zb-tooltip toggle-all-code" title="${message(code:'scriptletBatch.button.showAllCode', default:'Show All Code')}"
+     style="display: none"
+     onclick="$(this).parent().find('pre').toggle();" >
+    <i class="icon-eye-close"></i>
+  </a>
   <span id="scriptdir-${i}_spinner_${type}" class="hide">
     <img src="${resource(dir:'images',file:'spinner.gif')}" alt="Spinner" />
   </span>


### PR DESCRIPTION
I often find that I want to search in the whole code of the script stack, but the GUI currently only offers the possibility to show the code of a single script, not all at once.

This adds a button (that only appears when the script stack is expanded), that allows to show all the code in the script stack at once.

It uses the same icon that is used to expand a single script, but IMHO the position should make the difference in functionality clear.