### PR TITLE
fix creation of exposed action by turning executionZone to an alias f…

### DIFF
--- a/grails-app/controllers/org/zenboot/portal/processing/ExposedExecutionZoneActionController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/processing/ExposedExecutionZoneActionController.groovy
@@ -222,10 +222,22 @@ class SaveExposedExecutionZoneActionCommand extends AbstractExecutionZoneCommand
     def grailsLinkGenerator
     def params
 
-    Long executionZone
     String url
     String cronExpression
     Set roles = []
+
+    // Long executionZone and AbstractExecutionZoneCommand's execId have the exact same meaning.
+    // Tracking down all the uses of "executionZone" in the code an converting them to execId seems too error-prone
+    // (as we might catch some false ones and introduce more bugs that way),
+    // so it seems safer to introduce an alias:
+    @SuppressWarnings("GroovyUnusedDeclaration")
+    public void setExecutionZone(Long executionZone) {
+        this.execId = executionZone
+    }
+
+    public Long getExecutionZone() {
+        return this.execId
+    }
 
     boolean validate() {
         boolean result = true


### PR DESCRIPTION
…or execId

SaveExposedExecutionZoneActionCommand has a property executionZone which
contains the ID of the executionZone, which is supposed to be in
AbstractExecutionZoneCommand.execId (at least there is code that expects
it).

But when creating an exposedExecutionZoneAction, only executionZone is
filled.

I selected the lazy solution of turning `executionZone` into an alias
for `execId`. That way we don't have to track down every usage of
SaveExposedExecutionZoneActionCommand.executionZone to convert it to
execId..