### PR TITLE
Feature/access cache

### DIFF
--- a/grails-app/conf/BaseNavigation.groovy
+++ b/grails-app/conf/BaseNavigation.groovy
@@ -62,7 +62,7 @@ navigation = {
             users titleText: 'User Management', action: 'user'
             notifications controller: 'userNotification', titleText: 'User Notifications', action: 'list'
             dbConsole titleText: 'DB Console', action: 'dbconsole'
-
+            accessCache titleText:'Access Cache', action: 'accessCache'
         }
     }
 }

--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -11,6 +11,7 @@ import org.zenboot.portal.security.Role
 class BootStrap {
 
     def executionZoneService
+    def accessService
     def grailsApplication
     def scriptDirectoryService
 
@@ -51,6 +52,8 @@ class BootStrap {
             returnArray['serviceUrls'] = it.serviceUrls
             return returnArray
         }
+
+        accessService.warmAccessCacheAsync()
     }
 
     private setupSecurity() {

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -122,6 +122,7 @@ environments {
         // TODO: grails.serverURL = "http://www.changeme.com"
         grails.mail.host = "localhost"
         grails.mail.port = 25
+        grails.assets.enableSourceMaps = false
     }
 }
 

--- a/grails-app/controllers/AdministrationController.groovy
+++ b/grails-app/controllers/AdministrationController.groovy
@@ -1,6 +1,8 @@
 
 class AdministrationController {
 
+    def accessService
+
     def index = {
         redirect(action:"user")
     }
@@ -8,4 +10,13 @@ class AdministrationController {
     def user = {}
 
     def dbconsole = {}
+
+    def accessCache = {}
+
+    def clear = {
+      accessService.clearAccessCache()
+      redirect(action:"accessCacheCleared")
+    }
+
+    def accessCacheCleared = {}
 }

--- a/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
@@ -1,4 +1,16 @@
 package org.zenboot.portal.security
 
 class RoleController extends grails.plugin.springsecurity.ui.RoleController {
+
+    def accessService
+
+    def edit() {
+        accessService.refreshAccessCacheByRole(Role.findById(params.id))
+        doEdit()
+    }
+
+    def delete() {
+        accessService.removeRoleFromChacheByRole(Role.findById(params.id))
+        super.delete()
+    }
 }

--- a/grails-app/controllers/org/zenboot/portal/security/UserController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/security/UserController.groovy
@@ -2,6 +2,8 @@ package org.zenboot.portal.security
 
 class UserController extends grails.plugin.springsecurity.ui.UserController {
 
+    def accessService
+
     @Override
     def search() {
         if (!isSearch()) {
@@ -26,4 +28,15 @@ class UserController extends grails.plugin.springsecurity.ui.UserController {
         renderSearch results: results, totalCount: results.totalCount,
             'accountExpired', 'accountLocked', 'enabled', 'passwordExpired', 'username', 'email', 'displayName'
     }
+
+    def edit() {
+        accessService.refreshAccessCacheByUser(Person.findById(params.id))
+        doEdit()
+    }
+
+    def delete() {
+        accessService.removeUserFromCacheByUser(Person.findById(params.id))
+        super.delete()
+    }
+
 }

--- a/grails-app/domain/org/zenboot/portal/processing/ExecutionZone.groovy
+++ b/grails-app/domain/org/zenboot/portal/processing/ExecutionZone.groovy
@@ -89,7 +89,9 @@ class ExecutionZone implements Likeable {
         } else {
             this.processingParameters << param
         }
-        accessService.invalidateAccessCacheByZone(this)
+        this.withNewSession {
+          accessService.invalidateAccessCacheByZone(this)
+        }
     }
 
     /* convenience-method for script-usage

--- a/grails-app/domain/org/zenboot/portal/processing/ExecutionZone.groovy
+++ b/grails-app/domain/org/zenboot/portal/processing/ExecutionZone.groovy
@@ -24,6 +24,8 @@ class ExecutionZone implements Likeable {
 
     SortedSet templates
 
+    def accessService
+
     static hasMany = [actions:ExecutionZoneAction, processingParameters:ProcessingParameter, templates:Template, hosts:Host]
 
     static constraints = {
@@ -87,6 +89,7 @@ class ExecutionZone implements Likeable {
         } else {
             this.processingParameters << param
         }
+        accessService.invalidateAccessCacheByZone(this)
     }
 
     /* convenience-method for script-usage

--- a/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
@@ -9,14 +9,18 @@ class PersonRole implements Serializable {
 
 	def accessService
 
-	def beforeInsert() {
-		this.log.info("PersonRole.beforeCreate triggered!!")
-		accessService.invalidateAccessCacheByRole(this.role)
+	// If someone adds a role to a user, you have to invalidate the user-entry
+	// in the cache
+	def afterInsert() {
+		this.log.info("PersonRole.afterInsert triggered!!")
+		accessService.invalidateAccessCacheByUser(this.person)
 	}
 
-	def beforeDelete() {
-		this.log.info("PersonRole.beforeDelete triggered!!")
-		accessService.invalidateAccessCacheByRole(this.role)
+	// If someone removes a Role from a User, you have to invalidate the user-entry
+	// in the cache
+	def afterDelete() {
+		this.log.info("PersonRole.afterDelete triggered!!")
+		accessService.invalidateAccessCacheByUser(this.person)
 	}
 
 	boolean equals(other) {

--- a/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
@@ -14,7 +14,7 @@ class PersonRole implements Serializable {
 	def afterInsert() {
 		this.log.debug("PersonRole.afterInsert triggered!!")
 		this.withNewSession {
-			accessService.invalidateAccessCacheByUser(this.person)
+			accessService.refreshAccessCacheByUser(this.person)
 		}
 	}
 
@@ -23,7 +23,7 @@ class PersonRole implements Serializable {
 	def afterDelete() {
 		this.log.debug("PersonRole.afterDelete triggered!!")
 		this.withNewSession {
-			accessService.invalidateAccessCacheByUser(this.person)
+			accessService.refreshAccessCacheByUser(this.person)
 		}
 	}
 

--- a/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
@@ -13,14 +13,18 @@ class PersonRole implements Serializable {
 	// in the cache
 	def afterInsert() {
 		this.log.info("PersonRole.afterInsert triggered!!")
-		accessService.invalidateAccessCacheByUser(this.person)
+		this.withNewSession {
+			accessService.invalidateAccessCacheByUser(this.person)
+		}
 	}
 
 	// If someone removes a Role from a User, you have to invalidate the user-entry
 	// in the cache
 	def afterDelete() {
 		this.log.info("PersonRole.afterDelete triggered!!")
-		accessService.invalidateAccessCacheByUser(this.person)
+		this.withNewSession {
+			accessService.invalidateAccessCacheByUser(this.person)
+		}
 	}
 
 	boolean equals(other) {

--- a/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
@@ -12,7 +12,7 @@ class PersonRole implements Serializable {
 	// If someone adds a role to a user, you have to invalidate the user-entry
 	// in the cache
 	def afterInsert() {
-		this.log.info("PersonRole.afterInsert triggered!!")
+		this.log.debug("PersonRole.afterInsert triggered!!")
 		this.withNewSession {
 			accessService.invalidateAccessCacheByUser(this.person)
 		}
@@ -21,7 +21,7 @@ class PersonRole implements Serializable {
 	// If someone removes a Role from a User, you have to invalidate the user-entry
 	// in the cache
 	def afterDelete() {
-		this.log.info("PersonRole.afterDelete triggered!!")
+		this.log.debug("PersonRole.afterDelete triggered!!")
 		this.withNewSession {
 			accessService.invalidateAccessCacheByUser(this.person)
 		}

--- a/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
@@ -7,26 +7,6 @@ class PersonRole implements Serializable {
 	Person person
 	Role role
 
-	def accessService
-
-	// If someone adds a role to a user, you have to invalidate the user-entry
-	// in the cache
-	def afterInsert() {
-		this.log.debug("PersonRole.afterInsert triggered!!")
-		this.withNewSession {
-			accessService.refreshAccessCacheByUser(this.person)
-		}
-	}
-
-	// If someone removes a Role from a User, you have to invalidate the user-entry
-	// in the cache
-	def afterDelete() {
-		this.log.debug("PersonRole.afterDelete triggered!!")
-		this.withNewSession {
-			accessService.refreshAccessCacheByUser(this.person)
-		}
-	}
-
 	boolean equals(other) {
 		if (!(other instanceof PersonRole)) {
 			return false

--- a/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/PersonRole.groovy
@@ -7,6 +7,18 @@ class PersonRole implements Serializable {
 	Person person
 	Role role
 
+	def accessService
+
+	def beforeInsert() {
+		this.log.info("PersonRole.beforeCreate triggered!!")
+		accessService.invalidateAccessCacheByRole(this.role)
+	}
+
+	def beforeDelete() {
+		this.log.info("PersonRole.beforeDelete triggered!!")
+		accessService.invalidateAccessCacheByRole(this.role)
+	}
+
 	boolean equals(other) {
 		if (!(other instanceof PersonRole)) {
 			return false

--- a/grails-app/domain/org/zenboot/portal/security/Role.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/Role.groovy
@@ -22,8 +22,8 @@ class Role {
         authority blank: false, unique: true
     }
 
-    def beforeUpdate() {
-      this.log.info("Role.beforeUpdate triggered!!")
+    def afterUpdate() {
+      this.log.info("Role.afterUpdate triggered!!")
       this.withNewSession {
         accessService.invalidateAccessCacheByRole(this)
       }

--- a/grails-app/domain/org/zenboot/portal/security/Role.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/Role.groovy
@@ -14,10 +14,17 @@ class Role {
     // is allowed to edit that parameter
     String parameterEditExpression
 
+    transient accessService
+
     static mapping = { cache true }
 
     static constraints = {
         authority blank: false, unique: true
+    }
+
+    def beforeUpdate() {
+      this.log.info("Role.beforeUpdate triggered!!")
+      accessService.invalidateAccessCacheByRole(this)
     }
 
     @Override

--- a/grails-app/domain/org/zenboot/portal/security/Role.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/Role.groovy
@@ -24,7 +24,9 @@ class Role {
 
     def beforeUpdate() {
       this.log.info("Role.beforeUpdate triggered!!")
-      accessService.invalidateAccessCacheByRole(this)
+      this.withNewSession {
+        accessService.invalidateAccessCacheByRole(this)
+      }
     }
 
     @Override

--- a/grails-app/domain/org/zenboot/portal/security/Role.groovy
+++ b/grails-app/domain/org/zenboot/portal/security/Role.groovy
@@ -14,19 +14,12 @@ class Role {
     // is allowed to edit that parameter
     String parameterEditExpression
 
-    transient accessService
+//    transient accessService
 
     static mapping = { cache true }
 
     static constraints = {
         authority blank: false, unique: true
-    }
-
-    def afterUpdate() {
-      this.log.info("Role.afterUpdate triggered!!")
-      this.withNewSession {
-        accessService.invalidateAccessCacheByRole(this)
-      }
     }
 
     @Override

--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -1,30 +1,89 @@
 package org.zenboot.portal.processing
 
 import grails.plugin.springsecurity.SpringSecurityUtils
+import org.zenboot.portal.security.Person
 import org.zenboot.portal.security.Role
 
 @SuppressWarnings("GroovyUnusedDeclaration")
 public class AccessService {
     def springSecurityService
 
-    public boolean roleHasAccess(Role role, ExecutionZone executionZone) {
+    def accessCache
+
+    private boolean roleHasAccess(Role role, ExecutionZone executionZone) {
         def expression = role.executionZoneAccessExpression
         try {
             return Eval.me("executionZone", executionZone, expression == null ? "" : expression)
+
         } catch (Exception e) {
             this.log.error("executionZoneAccessExpression '$expression' from role '$role' threw an exception", e)
             return false
         }
     }
 
-    public boolean rolesHaveAccess(Set<Role> roles, ExecutionZone zone) {
-        roles.find() {
-            roleHasAccess(it, zone)
-        }
+    private boolean rolesHaveAccess(Set<Role> roles, ExecutionZone zone) {
+      roles.any() {
+        roleHasAccess(it, zone)
+      }
     }
 
     public boolean userHasAccess(ExecutionZone zone) {
-        SpringSecurityUtils.ifAllGranted(Role.ROLE_ADMIN) ||
-            rolesHaveAccess(springSecurityService.currentUser.getAuthorities(), zone)
+      SpringSecurityUtils.ifAllGranted(Role.ROLE_ADMIN) ||
+        userHasAccess(springSecurityService.currentUser, zone)
+    }
+
+    public boolean userHasAccess(Person user, ExecutionZone zone) {
+      if (accessCache == null) {
+        this.log.info("initializing accessCache")
+        accessCache = [:]
+      }
+      if (accessCache[zone.id] == null) {
+        this.log.info("zone ${zone} not found in cache, creating")
+        accessCache[zone.id] = [:]
+      }
+      if (accessCache[zone.id][user.id] == null) {
+        def hasAccess = rolesHaveAccess(user.getAuthorities(), zone)
+        accessCache[zone.id][user.id] = hasAccess
+      } else {
+        accessCache[zone.id][user.id]
+      }
+    }
+
+    public invalidateAccessCacheByZone(ExecutionZone zone) {
+      accessCache[zone.id] = null
+    }
+
+    public invalidateAccessCacheByUser(Person user) {
+      this.log.info("invalidating ${user} in accessCache")
+      if (accessCache != null) {
+        accessCache.each() {
+          it.remove(user.id)
+        }
+      }
+    }
+
+    public invalidateAccessCacheByRole(Role role) {
+      this.log.info("invalidating ${role} in accessCache")
+      if (accessCache != null) {
+        def users = UserRole.findAllByRole(role).user
+        users.each() {
+          invalidateAccessCacheByUser(it)
+        }
+      }
+    }
+
+    public warmAccessCacheAsync() {
+      runAsync {
+        this.log.info("Warming the accessCache")
+        def execZones = ExecutionZone.findAll()
+        execZones.each() { zone ->
+          this.log.info("Warming accessCache for zone ${zone}")
+          Person.findAll().each() { person ->
+            this.log.info("Warming accessCache for person ${person}")
+            this.userHasAccess(person, zone)
+            Thread.sleep(500)
+          }
+        }
+      }
     }
 }

--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -15,6 +15,16 @@ public class AccessService {
        {1={1=false, 2=true, 3=false, 4=false}, 2={1=false, 2=false, 3=false, 4=false}}
        The fist level is a ExecutionZone.id, the second Level is a Person.id and
        the boolean is the access from that person to that zone
+
+       Memory Footprint:
+       ConcurrentHashMap about 128 byte
+       Long 20 byte
+       Boolean 16 byte
+       64 bit system means X 1.8
+       ConcurrentHasmaps<1000 Long, ConcurrentHashmap<1000 Long,Boolean>>
+
+       ==> ((1000 * (128 + 20)) + (1000 * (20 + 16))) * 1.8
+       ==> about 320kb for 1000 Users on 1000 Zones
     */
     def accessCache
 
@@ -40,35 +50,50 @@ public class AccessService {
         userHasAccess(springSecurityService.currentUser, zone)
     }
 
-    public boolean userHasAccess(Person user, ExecutionZone zone) {
+    // Might not be 100% Threadsafe but hopefully something above 99% ;-)
+    public synchronized boolean userHasAccess(Person user, ExecutionZone zone) {
       if (accessCache == null) {
         this.log.info("initializing accessCache")
         accessCache = new ConcurrentHashMap<Long, HashMap>()
       }
-      if (accessCache[zone.id] == null) {
-        this.log.info("zone ${zone} not found in cache, creating")
-        accessCache[zone.id] = new ConcurrentHashMap<Long, Boolean>()
+      if (accessCache[user.id] == null) {
+        this.log.info("user ${user} not found in cache, creating")
+
+        accessCache[user.id] = new ConcurrentHashMap<Long, Boolean>()
       }
-      if (accessCache[zone.id][user.id] == null) {
+      if (accessCache[user.id][zone.id] == null) {
         def hasAccess = rolesHaveAccess(user.getAuthorities(), zone)
-        accessCache[zone.id][user.id] = hasAccess
-      } else {
-        accessCache[zone.id][user.id]
+        // concurrency is quite unlikely here until users use multiple browsers
+        // impact would be a clash with the invalidate-methods
+        // 1. invalidation-method removed a user
+        //    --> NullPointer
+        try {
+          accessCache[user.id][zone.id] = hasAccess
+        } catch (NullPointerException npe) {
+          return false
+        }
+
+      }
+      try {
+        def hasAccess = accessCache[user.id][zone.id]
+        hasAccess || false
+      } catch (NullPointerException npe) {
+        return false
       }
     }
 
     public invalidateAccessCacheByZone(ExecutionZone zone) {
-      if (zone) {
-        accessCache[zone.id] = null
+      if (zone && accessCache) {
+        accessCache.each() { key, user ->
+          user.remove(zone.id)
+        }
       }
     }
 
     public invalidateAccessCacheByUser(Person user) {
       this.log.info("invalidating ${user} in accessCache")
-      if (accessCache) {
-        accessCache.each() { key, zone ->
-          zone.remove(user.id)
-        }
+      if (user && accessCache && accessCache[user.id]) {
+        accessCache.remove(user.id)
       }
     }
 
@@ -76,24 +101,31 @@ public class AccessService {
       this.log.info("invalidating ${role} in accessCache")
       if (accessCache) {
         def users = PersonRole.findAllByRole(role).person
-        users.each() {
-          invalidateAccessCacheByUser(it)
+        users.each() { user ->
+          invalidateAccessCacheByUser(user)
         }
       }
     }
 
-    public warmAccessCacheAsync() {
+    // synchronized as nervous finger protection (might be triggerable via UI)
+    public synchronized warmAccessCacheAsync() {
       runAsync {
         this.log.info("Warming the accessCache")
         def execZones = ExecutionZone.findAll()
         execZones.each() { zone ->
           this.log.info("Warming accessCache for zone ${zone}")
           Person.findAll().each() { person ->
-            this.log.info("Warming accessCache for person ${person}")
+            this.log.debug("Warming accessCache for person ${person}")
             this.userHasAccess(person, zone)
-            Thread.sleep(100)
+            Thread.sleep(50)
           }
         }
+        this.log.info("Finished Warming the accessCache")
       }
+    }
+
+    public clearAccessCache() {
+      this.log.info("clearing the accessCache")
+      accessCache = new ConcurrentHashMap<Long, HashMap>()
     }
 }

--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -8,7 +8,7 @@ import org.zenboot.portal.security.PersonRole
 import java.util.concurrent.ConcurrentHashMap
 
 @SuppressWarnings("GroovyUnusedDeclaration")
-public class AccessService {
+class AccessService {
     def springSecurityService
 
     /* The accessCache is a dynamic datastructure looking like this:
@@ -34,7 +34,7 @@ public class AccessService {
             return Eval.me("executionZone", executionZone, expression == null ? "" : expression)
 
         } catch (Exception e) {
-            this.log.error("executionZoneAccessExpression '$expression' from role '$role' threw an exception", e)
+            log.error("executionZoneAccessExpression '$expression' from role '$role' threw an exception", e)
             return false
         }
     }
@@ -45,43 +45,48 @@ public class AccessService {
       }
     }
 
-    public boolean userHasAccess(ExecutionZone zone) {
+    boolean userHasAccess(ExecutionZone zone) {
       SpringSecurityUtils.ifAllGranted(Role.ROLE_ADMIN) ||
-        userHasAccess(springSecurityService.currentUser, zone)
+        testIfUserHasAccess(springSecurityService.currentUser, zone)
     }
 
     // Might not be 100% Threadsafe but hopefully something above 99% ;-)
-    public synchronized boolean userHasAccess(Person user, ExecutionZone zone) {
-      if (accessCache == null) {
-        this.log.info("initializing accessCache")
-        accessCache = new ConcurrentHashMap<Long, HashMap>()
-      }
-      if (accessCache[user.id] == null) {
-        this.log.info("user ${user} not found in cache, creating")
+    private synchronized boolean testIfUserHasAccess(Person user, ExecutionZone zone) {
 
-        accessCache[user.id] = new ConcurrentHashMap<Long, Boolean>()
-      }
-      if (accessCache[user.id][zone.id] == null) {
-        def hasAccess = rolesHaveAccess(user.getAuthorities(), zone)
-        // concurrency is quite unlikely here until users use multiple browsers
-        // impact would be a clash with the invalidate-methods
-        // 1. invalidation-method removed a user
-        //    --> NullPointer
-        try {
-          accessCache[user.id][zone.id] = hasAccess
-        } catch (NullPointerException npe) {
-          log.error("userHasAccess threw NPE, returning false")
-          return false
+        if (user.getAuthorities().authority.contains(Role.ROLE_ADMIN)) {
+            //no cache required for admin user
+            return true
         }
 
+        if (!accessCache) {
+            log.info("initializing accessCache")
+            accessCache = new ConcurrentHashMap<Long, HashMap>()
+        }
+
+        if (!accessCache[user.id]) {
+            log.info("user ${user} not found in cache, creating")
+            accessCache[user.id] = new ConcurrentHashMap<Long, Boolean>()
+        }
+
+        if (!accessCache[user.id][zone.id]) {
+            def hasAccess = rolesHaveAccess(user.getAuthorities(), zone)
+            // concurrency is quite unlikely here until users use multiple browsers
+            // impact would be a clash with the invalidate-methods
+            // 1. invalidation-method removed a user
+            //    --> NullPointer
+
+          if (hasAccess != null) {
+              accessCache[user.id][zone.id] = hasAccess
+          }
+          else {
+              log.error("hasAccess is null, returning false")
+              return false
+          }
       }
-      try {
-        def hasAccess = accessCache[user.id][zone.id]
-        hasAccess || false
-      } catch (NullPointerException npe) {
-        log.error("userHasAccess threw NPE, returning false")
-        return false
-      }
+
+        def hasAccess = accessCache[user.id][zone.id] ?: false
+
+        return hasAccess
     }
 
     /* The cache invalidation methods are not implemented symetrically for
@@ -93,57 +98,93 @@ public class AccessService {
         * refresh for for Person/Role
         * invalidate only for a zone
     */
-    public invalidateAccessCacheByZone(ExecutionZone zone) {
-      if (zone && accessCache) {
-        this.log.info("invalidating ${zone} in accessCache")
-        accessCache.each() { key, user ->
-          user.remove(zone.id)
+    def invalidateAccessCacheByZone(ExecutionZone zone) {
+        if (zone && accessCache) {
+            log.info("invalidating ${zone} in accessCache")
+            accessCache.each() { key, user ->
+                user.remove(zone.id)
+            }
         }
-      }
     }
 
-    public refreshAccessCacheByUser(Person user) {
-      if (user && accessCache && accessCache[user.id]) {
-        this.log.info("Refreshing ${user} in accessCache")
-        this.log.info("user has roles "+user.getAuthorities())
-        accessCache.remove(user.id)
-        def execZones = ExecutionZone.findAll()
-        execZones.each() { zone ->
-          this.userHasAccess(user, zone)
+    def refreshAccessCacheByUser(Person user) {
+
+        if (user) {
+
+            if (user.getAuthorities().authority.contains(Role.ROLE_ADMIN)) {
+                //no cache required for admin user
+                return
+            }
+
+            //remove existing user from cache
+            accessCache?.remove(user.id)
+
+            log.info("Refreshing ${user} in accessCache")
+            log.info("user has roles " + user.getAuthorities())
+
+            ExecutionZone.findAll().each { zone -> testIfUserHasAccess(user, zone) }
+
+            log.info(accessCache[user.id].collect { it.value })
         }
-        this.log.info(accessCache[user.id].collect{it.value})
-      }
+        else {
+            log.info("Cannot refresh access cache for null user")
+        }
     }
 
-    public refreshAccessCacheByRole(Role role) {
-      this.log.info("Refreshing ${role} in accessCache")
-      if (accessCache) {
+    def removeUserFromCacheByUser(Person user) {
+        if (user) {
+            accessCache?.remove(user.id)
+            log.info("User ${user} removed from cache")
+        }
+    }
+
+    def refreshAccessCacheByRole(Role role) {
+
+        if (role.authority == Role.ROLE_ADMIN) {
+            //no cache required for admin user
+            return
+        }
+
+        log.info("Refreshing ${role} in accessCache")
         def users = PersonRole.findAllByRole(role).person
-        users.each() { user ->
-          refreshAccessCacheByUser(user)
-        }
-      }
+        users.each() { user -> refreshAccessCacheByUser(user) }
     }
+
+    def removeRoleFromChacheByRole(Role role) {
+        if (role) {
+            def users = PersonRole.findAllByRole(role).person
+
+            log.info("Removing role ${role} from cache. Updating affected users...")
+            users.each { user ->
+                //because the update in database will be done after this the role have to be removed by hand from the user object
+                if (user.getAuthorities().remove(role)) {
+                    log.info("Affected user: ${user}")
+                    refreshAccessCacheByUser(user)
+                }
+            }
+        }
+    }
+
 
     // synchronized as nervous finger protection (might be triggerable via UI)
-    public synchronized warmAccessCacheAsync() {
-      runAsync {
-        this.log.info("Warming the accessCache")
-        def execZones = ExecutionZone.findAll()
-        execZones.each() { zone ->
-          this.log.info("Warming accessCache for zone ${zone}")
-          Person.findAll().each() { user ->
-            this.log.debug("Warming accessCache for person ${user}")
-            this.userHasAccess(user, zone)
-            Thread.sleep(50)
+    def synchronized warmAccessCacheAsync() {
+        runAsync {
+          log.info("Warming the accessCache")
+          def execZones = ExecutionZone.findAll()
+          execZones.each() { zone ->
+            log.info("Warming accessCache for zone ${zone}")
+            Person.findAll().each() { user ->
+              log.debug("Warming accessCache for person ${user}")
+              testIfUserHasAccess(user, zone)
+              Thread.sleep(50)
           }
         }
-        this.log.info("Finished Warming the accessCache")
+        log.info("Finished Warming the accessCache")
       }
     }
 
-    public clearAccessCache() {
-      this.log.info("clearing the accessCache")
+    def clearAccessCache() {
+      log.info("clearing the accessCache")
       accessCache = new ConcurrentHashMap<Long, HashMap>()
     }
 }

--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -3,11 +3,17 @@ package org.zenboot.portal.processing
 import grails.plugin.springsecurity.SpringSecurityUtils
 import org.zenboot.portal.security.Person
 import org.zenboot.portal.security.Role
+import org.zenboot.portal.security.PersonRole
 
 @SuppressWarnings("GroovyUnusedDeclaration")
 public class AccessService {
     def springSecurityService
 
+    /* The accessCache is a dynamic datastructure looking like this:
+       {1={1=false, 2=true, 3=false, 4=false}, 2={1=false, 2=false, 3=false, 4=false}}
+       The fist level is a ExecutionZone.id, the second Level is a Person.id and
+       the boolean is the access from that person to that zone
+    */
     def accessCache
 
     private boolean roleHasAccess(Role role, ExecutionZone executionZone) {
@@ -56,8 +62,8 @@ public class AccessService {
     public invalidateAccessCacheByUser(Person user) {
       this.log.info("invalidating ${user} in accessCache")
       if (accessCache != null) {
-        accessCache.each() {
-          it.remove(user.id)
+        accessCache.each() { key, zone ->
+          zone.remove(user.id)
         }
       }
     }
@@ -65,7 +71,7 @@ public class AccessService {
     public invalidateAccessCacheByRole(Role role) {
       this.log.info("invalidating ${role} in accessCache")
       if (accessCache != null) {
-        def users = UserRole.findAllByRole(role).user
+        def users = PersonRole.findAllByRole(role).person
         users.each() {
           invalidateAccessCacheByUser(it)
         }

--- a/grails-app/views/administration/accesscache.gsp
+++ b/grails-app/views/administration/accesscache.gsp
@@ -1,0 +1,12 @@
+<html>
+<head>
+<meta name="layout" content="main" />
+</head>
+<body>
+  <g:form action="clear">
+    <fieldset class="buttons spacer">
+      <g:submitButton class="btn btn-primary" action="clear" name="${message(code: 'default.button.clear.label', default: 'Clear')}" />
+    </fieldset>
+  </g:form>
+</body>
+</html>

--- a/grails-app/views/administration/accesscacheCleared.gsp
+++ b/grails-app/views/administration/accesscacheCleared.gsp
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta name="layout" content="main" />
+</head>
+<body>
+The AccessCache has been cleared
+</body>
+</html>


### PR DESCRIPTION
The zoneaccess-feature implemented in the accessService is quite performance expensive
for users. If you have more then 100 zones, you might wait more then a minute until the
system knows which zones you have access to.

The accessCache caches this information in in-memory-datastructure and should speed that up
significantly.

The cache get invalidated by calling GORM-callbacks in ExecutionZone, PersonRole and Role domain-objects.

In order to be effective, the cache needs to be warmed up at startup-time in bootstrap.