### PR TITLE
Feature/access cache

### DIFF
--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -4,6 +4,8 @@ import org.zenboot.portal.Host
 import org.zenboot.portal.processing.ExecutionZone
 import org.zenboot.portal.processing.ExecutionZoneType
 import org.zenboot.portal.processing.ExposedExecutionZoneAction
+import org.zenboot.portal.processing.Processable
+import org.zenboot.portal.processing.ScriptletBatch
 import org.zenboot.portal.security.Person
 import org.zenboot.portal.security.PersonRole
 import org.zenboot.portal.security.Role
@@ -51,6 +53,12 @@ class BootStrap {
             returnArray['hostname'] = it.hostname
             returnArray['serviceUrls'] = it.serviceUrls
             return returnArray
+        }
+
+        //clean up hung stuff after restart
+        ScriptletBatch.findAll { state == Processable.ProcessState.RUNNING || state == Processable.ProcessState.WAITING }.each {
+            it.state = Processable.ProcessState.CANCELED
+            it.save(flush:true)
         }
 
         accessService.warmAccessCacheAsync()

--- a/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
@@ -4,6 +4,22 @@ class RoleController extends grails.plugin.springsecurity.ui.RoleController {
 
     def accessService
 
+    def search() {
+        if (!isSearch()) {
+            // show the form
+            return
+        }
+
+        params.sort = 'authority'
+        if (!param('authority')) params.authority = 'ROLE_'
+
+        def results = doSearch {
+            like 'authority', delegate
+        }
+
+        renderSearch([results: results, totalCount: results.totalCount], 'authority')
+    }
+
     def edit() {
         accessService.refreshAccessCacheByRole(Role.findById(params.id))
         doEdit()

--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -140,7 +140,7 @@ class AccessService {
 
     def refreshAccessCacheByRole(Role role) {
 
-        if (role?.authority == Role.ROLE_ADMIN) {
+        if (!role && role.authority == Role.ROLE_ADMIN) {
             //no cache required for admin user
             return
         }

--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -140,7 +140,7 @@ class AccessService {
 
     def refreshAccessCacheByRole(Role role) {
 
-        if (role.authority == Role.ROLE_ADMIN) {
+        if (role?.authority == Role.ROLE_ADMIN) {
             //no cache required for admin user
             return
         }
@@ -170,9 +170,10 @@ class AccessService {
         runAsync {
             log.info("Warming the accessCache")
             def execZones = ExecutionZone.findAll()
+            def persons = Person.getAll().findAll{ !it.getAuthorities().contains(Role.findByAuthority(Role.ROLE_ADMIN)) }
             execZones.each() { zone ->
                 log.info("Warming accessCache for zone ${zone}")
-                Person.findAll().each() { user ->
+                persons.each() { user ->
                     log.debug("Warming accessCache for person ${user}")
                     testIfUserHasAccess(user, zone)
                     Thread.sleep(50)


### PR DESCRIPTION
Fix 500 error when searching for specific role and get only one result. Change 'running' or 'waiting' processes to 'cancelled' after restart. Warumup cache will not execute test for admin users. Database request to get all users removed from loop.