### PR TITLE
Replace edit with update method 

### DIFF
--- a/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
@@ -20,9 +20,9 @@ class RoleController extends grails.plugin.springsecurity.ui.RoleController {
         renderSearch([results: results, totalCount: results.totalCount], 'authority')
     }
 
-    def edit() {
-        accessService.refreshAccessCacheByRole(Role.findById(params.id))
-        doEdit()
+    def update() {
+        accessService.refreshAccessCacheByUser(Person.findById(params.id))
+        super.update()
     }
 
     def delete() {

--- a/grails-app/controllers/org/zenboot/portal/security/UserController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/security/UserController.groovy
@@ -29,9 +29,9 @@ class UserController extends grails.plugin.springsecurity.ui.UserController {
                 'accountExpired', 'accountLocked', 'enabled', 'passwordExpired', 'username', 'email', 'displayName'
     }
 
-    def edit() {
+    def update() {
         accessService.refreshAccessCacheByUser(Person.findById(params.id))
-        doEdit()
+        super.update()
     }
 
     def delete() {


### PR DESCRIPTION
edit is not called when you edit the user but rather if you want to display the user/role which you want to edit. As a result of this the update cache method will only be called if a user/role has been changed.