### PR TITLE
Typo in method name fixed. Warmup process of the cache improved.

### DIFF
--- a/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
@@ -21,12 +21,16 @@ class RoleController extends grails.plugin.springsecurity.ui.RoleController {
     }
 
     def update() {
-        accessService.refreshAccessCacheByUser(Person.findById(params.id))
+        accessService.refreshAccessCacheByRole(Role.findById(params.id))
         super.update()
     }
 
     def delete() {
         accessService.removeRoleFromCacheByRole(Role.findById(params.id))
         super.delete()
+    }
+
+    def save() {
+        doSave uiRoleStrategy.saveRole(params), {accessService.refreshAccessCacheByRole(Role.findByAuthority(params.authority))}
     }
 }

--- a/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/security/RoleController.groovy
@@ -26,7 +26,7 @@ class RoleController extends grails.plugin.springsecurity.ui.RoleController {
     }
 
     def delete() {
-        accessService.removeRoleFromChacheByRole(Role.findById(params.id))
+        accessService.removeRoleFromCacheByRole(Role.findById(params.id))
         super.delete()
     }
 }

--- a/grails-app/controllers/org/zenboot/portal/security/UserController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/security/UserController.groovy
@@ -39,4 +39,8 @@ class UserController extends grails.plugin.springsecurity.ui.UserController {
         super.delete()
     }
 
+    def save() {
+        doSave uiUserStrategy.saveUser(params, roleNamesFromParams(), params.password) ,{accessService.refreshAccessCacheByUser(Person.findByUsername(params.username))}
+    }
+
 }

--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -236,13 +236,12 @@ class AccessService {
                 }
             }
 
-            accessCache?.keys().each { personId ->
-                accessCache[personId].keys().each { zoneId ->
-                    preAccessCache[personId][zoneId] = accessCache[personId][zoneId]
-                }
+            if(accessCache == null) {
+                accessCache = new ConcurrentHashMap<Long, HashMap>()
             }
 
-            accessCache = preAccessCache
+            preAccessCache.putAll(accessCache)
+            accessCache.putAll(preAccessCache)
 
             log.info("Finished Warming the accessCache")
         }

--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -141,7 +141,12 @@ class AccessService {
 
     def refreshAccessCacheByRole(Role role) {
 
-        if (!role && role.authority == Role.ROLE_ADMIN) {
+        if (role == null) {
+            log.info("Cannot refresh access cache for null role")
+            return
+        }
+
+        if (Role.ROLE_ADMIN == role.authority) {
             //no cache required for admin user
             return
         }


### PR DESCRIPTION
 Instead of checking each role for each user in each zone, the new process checks first which role has access to which execution zone. After that it requests all users by role and set access to true for the related execution zones. Finally it completes the cache with false for each user which has no has no access to the execution zone.