### PR TITLE
'Home' restructured - a new navigation item 'Overview' created where …

### DIFF
--- a/grails-app/conf/BaseNavigation.groovy
+++ b/grails-app/conf/BaseNavigation.groovy
@@ -6,7 +6,9 @@ def isAdmin = { ->
 
 navigation = {
     base {
-        home()
+        home(controller: 'home', titleText: 'Home', action: 'index') {
+            overview titleText: 'Overview'
+        }
 
         executionZone(controller: 'executionZone', titleText: 'Processing', action: 'list') {
             list titleText: 'Execution Zone'

--- a/grails-app/controllers/HomeController.groovy
+++ b/grails-app/controllers/HomeController.groovy
@@ -9,29 +9,29 @@ import org.zenboot.portal.processing.Processable.ProcessState
 class HomeController {
 
     def index() {
+        [empty: true]
+    }
 
-      int allHostsCount = Host.count()
-      int completedHostsCount = Host.countByState(HostState.COMPLETED)
-      int stillRunningRate = completedHostsCount / (allHostsCount != 0 ? allHostsCount : 1) * 100
+    def overview = {
+        int allHostsCount = Host.count()
+        int completedHostsCount = Host.countByState(HostState.COMPLETED)
+        int stillRunningRate = completedHostsCount / (allHostsCount != 0 ? allHostsCount : 1) * 100
+        def allActiveExecutionZone = ExecutionZone.findAllByEnabled(true)
+        int allActiveExecutionZoneCount = allActiveExecutionZone.size()
+        int maxHostsExecutionZoneHostCount = allActiveExecutionZone.collect {it.getNonDeletedHosts().size()}.max()
+        int allExecZoneActionCount = ScriptletBatch.count()
+        int successfulExecZoneActionCount = ScriptletBatch.countByState(ProcessState.SUCCESS)
+        int successRate = successfulExecZoneActionCount / (allExecZoneActionCount != 0 ? allExecZoneActionCount : 1) * 100
 
-      def allActiveExecutionZone = ExecutionZone.findAllByEnabled(true)
-      int allActiveExecutionZoneCount = allActiveExecutionZone.size()
-      int maxHostsExecutionZoneHostCount = allActiveExecutionZone.collect {it.getNonDeletedHosts().size()}.max()
-
-      int allExecZoneActionCount = ScriptletBatch.count()
-      int successfulExecZoneActionCount = ScriptletBatch.countByState(ProcessState.SUCCESS)
-      int successRate = successfulExecZoneActionCount / (allExecZoneActionCount != 0 ? allExecZoneActionCount : 1) * 100
-
-      [allHostsCount: allHostsCount,
-       completedHostsCount: completedHostsCount,
-       stillRunningRate: stillRunningRate,
-
-       allActiveExecutionZoneCount: allActiveExecutionZoneCount,
-       maxHostsExecutionZoneHostCount: maxHostsExecutionZoneHostCount,
-
-       allExecZoneActionCount: allExecZoneActionCount,
-       successfulExecZoneActionCount: successfulExecZoneActionCount,
-       successRate: successRate
+        [
+         allHostsCount: allHostsCount,
+         completedHostsCount: completedHostsCount,
+         stillRunningRate: stillRunningRate,
+         allActiveExecutionZoneCount: allActiveExecutionZoneCount,
+         maxHostsExecutionZoneHostCount: maxHostsExecutionZoneHostCount,
+         allExecZoneActionCount: allExecZoneActionCount,
+         successfulExecZoneActionCount: successfulExecZoneActionCount,
+         successRate: successRate
        ]
     }
 }

--- a/grails-app/controllers/org/zenboot/portal/processing/ScriptletBatchController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/processing/ScriptletBatchController.groovy
@@ -83,7 +83,7 @@ class ScriptletBatchController {
                 render output as JSON
             }
             html {
-                [scriptletBatchInstanceList:result, scriptletBatchInstanceTotal:ScriptletBatch.count()]
+                [scriptletBatchInstanceList:result]
             }
         }
     }

--- a/grails-app/controllers/org/zenboot/portal/security/UserController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/security/UserController.groovy
@@ -31,6 +31,12 @@ class UserController extends grails.plugin.springsecurity.ui.UserController {
 
     def update() {
         accessService.refreshAccessCacheByUser(Person.findById(params.id))
+        //for some reason it creates different personrole objects. Because the update method creates his own object it is required to discard
+        //the previous one
+        def pr = PersonRole.findAllByPerson(Person.findById(params.id))
+        pr.each {
+            it.discard()
+        }
         super.update()
     }
 

--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -128,8 +128,6 @@ class AccessService {
             log.info("user has roles " + user.getAuthorities())
 
             ExecutionZone.findAll().each { zone -> testIfUserHasAccess(user, zone) }
-
-            log.info(accessCache[user.id].collect { it.value })
         }
         else {
             log.info("Cannot refresh access cache for null user")

--- a/grails-app/services/org/zenboot/portal/processing/ExecutionZoneService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/ExecutionZoneService.groovy
@@ -13,6 +13,9 @@ import org.springframework.context.ApplicationEventPublisherAware
 import org.zenboot.portal.ControllerUtils
 import org.zenboot.portal.processing.meta.ParameterMetadata
 
+import javax.script.ScriptEngine
+import javax.script.ScriptEngineManager
+
 class ExecutionZoneService implements ApplicationEventPublisherAware {
     def runTimeAttributesService
     def grailsApplication
@@ -22,6 +25,8 @@ class ExecutionZoneService implements ApplicationEventPublisherAware {
     def hostService
     def accessService
     def scriptDirectoryService
+
+    private static ScriptEngine engine = new ScriptEngineManager().getEngineByName("groovy")
 
     void synchronizeExecutionZoneTypes() {
         //type name is the key to be able to resolve a type by name quickly
@@ -261,18 +266,19 @@ class ExecutionZoneService implements ApplicationEventPublisherAware {
 
     private Set overlayExecutionZoneParameters(ParameterMetadataList paramMetaList, Set overlayParameters) {
         log.debug("Entering overlayExecutionZoneParameters")
-		    Set parameters = paramMetaList.unsatisfiedParameters
+		Set parameters = paramMetaList.unsatisfiedParameters
         log.debug("yet unsatisfied parameters: " + parameters)
+
         parameters.each { ParameterMetadata paramMetaData ->
           ProcessingParameter param = overlayParameters.find { it.name == paramMetaData.name }
-  			  if (param) {
-            log.debug("filling param "+ paramMetaData.name + " with "+ param.value)
-            paramMetaData.metaClass.value = param.value
-            paramMetaData.metaClass.overlay = true
+            if (param) {
+                  log.debug("filling param "+ paramMetaData.name + " with "+ param.value)
+                  paramMetaData.metaClass.value = param.value
+                  paramMetaData.metaClass.overlay = true
           } else {
-            log.debug("defaulting param "+ paramMetaData.name + " with " + paramMetaData.defaultValue)
-            paramMetaData.metaClass.value = paramMetaData.defaultValue
-  				  paramMetaData.metaClass.overlay = false
+                  log.debug("defaulting param "+ paramMetaData.name + " with " + paramMetaData.defaultValue)
+                  paramMetaData.metaClass.value = paramMetaData.defaultValue
+                  paramMetaData.metaClass.overlay = false
   			  }
 		    }
         // Now the other way around. We also want all the execZoneParams which
@@ -324,21 +330,14 @@ class ExecutionZoneService implements ApplicationEventPublisherAware {
       def expression = role.parameterEditExpression
 
       try {
-
-        def sharedData = new Binding()
-        def shell = new GroovyShell(sharedData)
-
-        sharedData.setProperty('parameterKey', parameter.name)
-        sharedData.setProperty('parameter', parameter)
-
-        return shell.evaluate(expression == null ? "" : expression)
-
+          def sharedData = new Binding()
+          sharedData.setProperty('parameterKey', parameter.name)
+          sharedData.setProperty('parameter', parameter)
+          return engine.eval(expression == null ? "" : expression, sharedData)
       } catch (Exception e) {
         this.log.error("parameterEditExpression for role '"+ role + " with " + expression +"' is throwing an exception", e)
         return false
       }
-
-
     }
 
     boolean canEdit(Set roles, ProcessingParameter parameter) {

--- a/grails-app/views/home/index.gsp
+++ b/grails-app/views/home/index.gsp
@@ -9,11 +9,6 @@
     <h1><g:message code="home.welcome" default="Welcome to Zenboot" /></h1>
     <br/>
     <p><g:message code="home.greeting" default="Your tool for system management." /></p>
-    <p>zenboot has booted ${allHostsCount} hosts so far whereas ${completedHostsCount} are still running (${stillRunningRate}%).</p>
-    <p>zenboot has done ${allExecZoneActionCount} executions
-      whereas ${successfulExecZoneActionCount} have been successful (${successRate}%)</p>
-    <p>${allActiveExecutionZoneCount} ExecutionZones have been created whereas the biggest has
-      ${maxHostsExecutionZoneHostCount} hosts</p>
   </div>
 </body>
 </html>

--- a/grails-app/views/home/overview.gsp
+++ b/grails-app/views/home/overview.gsp
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+    <title>Welcome</title>
+    <meta name="layout" content="main">
+</head>
+<body>
+<div class="hero-unit">
+    <g:set value="${request.contextPath}/overview" var="url" />
+    <h1><g:message code="home.overview" default="Overview" /></h1>
+    <br/>
+    <p>zenboot has booted ${allHostsCount} hosts so far whereas ${completedHostsCount} are still running (${stillRunningRate}%).</p>
+    <p>zenboot has done ${allExecZoneActionCount} executions
+    whereas ${successfulExecZoneActionCount} have been successful (${successRate}%)</p>
+    <p>${allActiveExecutionZoneCount} ExecutionZones have been created whereas the biggest has
+    ${maxHostsExecutionZoneHostCount} hosts</p>
+</div>
+</body>
+</html>

--- a/grails-app/views/layouts/main.gsp
+++ b/grails-app/views/layouts/main.gsp
@@ -15,7 +15,7 @@
 	<div class="row-fluid" id="header">
 		<div class="span2" id="logo">
 			<g:link uri="/">
-				<img src="${resource(dir: 'images', file: 'zenboot-logo.png')}" alt="Zenboot Logo" />
+				<img src="${resource(dir: 'images', file: 'zenboot-logo.png')}" alt="Zenboot Logo"/>
 			</g:link>
 		</div>
 
@@ -78,7 +78,8 @@
 
 	<sec:ifLoggedIn>
         <asset:script type="text/javascript">
-            $(document).ready(function() {
+			$(window).load(function() {
+
                 zenboot.startProcessQueue('<g:createLink controller="scriptletBatch" action="ajaxList" />', 5000)
             });
        </asset:script>


### PR DESCRIPTION
…the long loading requests are placed to speed up start page. Ajax request to update the process queue adapted. Now it starts the first time after the page is displayed instead of DOM loaded. The Ajax method itself was adapted - I removed the ScriptletBatch.count method from this call because this information is not use and requires a lot of loading time each 5 seconds. AccessCache had a problem while updating a specific user because a PersonalRole was already created for this session and so the spring security plugin fails - fixed.