### PR TITLE
Null and empty (whitespace chars) will no longer be added as processi…

### DIFF
--- a/grails-app/services/org/zenboot/portal/processing/ExecutionZoneService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/ExecutionZoneService.groovy
@@ -171,7 +171,9 @@ class ExecutionZoneService implements ApplicationEventPublisherAware {
 
 
         processParameters.each {
-          execAction.addProcessingParameter(it)
+            if(it?.value?.trim()) {
+                execAction.addProcessingParameter(it)
+            }
         }
 
         if (runtimeAttributes) {

--- a/grails-app/views/executionZone/_parameterList.gsp
+++ b/grails-app/views/executionZone/_parameterList.gsp
@@ -9,7 +9,7 @@
       <div class="control-group ${entry.overlay ? 'info' : entry.value ? 'success' : ''}">
         <g:if test="${entry.visible || (!entry.visible && entry.value.empty)}">
           <sec:ifAllGranted roles="${Role.ROLE_ADMIN}">
-            <g:textField name="parameters.value" value="${entry.value}" />
+            <g:textField name="parameters.value" value="${entry.value}" required="required"/>
           </sec:ifAllGranted>
           <sec:ifNotGranted roles="${Role.ROLE_ADMIN}">
             <g:textField name="parameters.value" value="${entry.value}" readonly="${readonly}"/>


### PR DESCRIPTION
…ng parameters to executionzoneaction. To avoid unnecessary loading time I added a required tag into the _parameterList.gsp - in the past it was executed and redirected to the page with a kind of error message that the values for the parameters have to be set. Now the gsp detects the empty column and will not send the form until the field is filled. This will fix https://github.com/hybris/zenboot/issues/84