### PR TITLE
Fix for accessCache refreshAccessCacheByZone - only was person of all…

### DIFF
--- a/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
+++ b/grails-app/services/org/zenboot/portal/processing/AccessService.groovy
@@ -116,8 +116,8 @@ class AccessService {
 
             cleanedRoles.each {
                 if (roleHasAccess(it, zone)) {
-                    if(PersonRole.findByRole(it)?.person) {
-                        persons_with_access.addAll(PersonRole.findByRole(it).person)
+                    if(PersonRole.findAllByRole(it)?.person) {
+                        persons_with_access.addAll(PersonRole.findAllByRole(it).person)
                     }
                 }
             }


### PR DESCRIPTION
… persons with access was added to the list. Now all persons for the role with access will be added to the list and the access cache will be updated correctly