### PR TITLE
Golang: Add ignore flag & Unify indent and ordering

### DIFF
--- a/zenboot-cli/cmd/call.go
+++ b/zenboot-cli/cmd/call.go
@@ -21,7 +21,7 @@ var callCmd = &cobra.Command{
 		}
 		rest_call := args[0]
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		content, err := rest.SendGet(rest_call)
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/clone.go
+++ b/zenboot-cli/cmd/clone.go
@@ -18,7 +18,7 @@ var cloneCmd = &cobra.Command{
 	Short: "clone an existing Execution Zone",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		content, err := rest.SendGet("executionzones/" + strconv.Itoa(id) + "/clone")
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/create.go
+++ b/zenboot-cli/cmd/create.go
@@ -20,7 +20,7 @@ var createCmd = &cobra.Command{
 	Use:   "create [flags]",
 	Short: "create a new execution zone based on the data in the JSON object",
 	Run: func(cmd *cobra.Command, args []string) {
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		if len(paramFile) <= 0 {
 			log.Fatalln("Please prvoide an Execution Zone Template.")

--- a/zenboot-cli/cmd/execute.go
+++ b/zenboot-cli/cmd/execute.go
@@ -50,7 +50,7 @@ var executeCmd = &cobra.Command{
 		action, err := lib.ValidateAction(args[0])
 		lib.HandleError(err)
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		parameters, err := rest.SendGet("executionzones/" + strconv.Itoa(id) + "/actions/" + action + "/listparams")
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/gettemplate.go
+++ b/zenboot-cli/cmd/gettemplate.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+
 	"../lib"
 	"github.com/spf13/cobra"
-	"os"
-	"bufio"
 )
 
 var path string

--- a/zenboot-cli/cmd/gettemplate.go
+++ b/zenboot-cli/cmd/gettemplate.go
@@ -20,7 +20,7 @@ var gettemplateCmd = &cobra.Command{
 	Short: "generate a template file for creating new zones",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		if path == "" {
 			path = "./template.json"

--- a/zenboot-cli/cmd/listactions.go
+++ b/zenboot-cli/cmd/listactions.go
@@ -18,7 +18,7 @@ var listActionsCmd = &cobra.Command{
 	Short: "list all action names of the specific Execution Zone",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		content, err := rest.SendGet("executionzones/" + strconv.Itoa(id) + "/actions/list")
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/listattributes.go
+++ b/zenboot-cli/cmd/listattributes.go
@@ -19,8 +19,8 @@ var listAttribsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
-        content, err := rest.SendGet("executionzones/" + strconv.Itoa(id) + "/attributes/list")
-        lib.HandleError(err)
+		content, err := rest.SendGet("executionzones/" + strconv.Itoa(id) + "/attributes/list")
+		lib.HandleError(err)
 
 		prettyjson, _ := prettyjson.Format(content)
 		fmt.Println(string(prettyjson))

--- a/zenboot-cli/cmd/listattributes.go
+++ b/zenboot-cli/cmd/listattributes.go
@@ -17,7 +17,7 @@ var listAttribsCmd = &cobra.Command{
 	Use:   "attributes [flags]",
 	Short: "list all attributes of an Execution Zone",
 	Run: func(cmd *cobra.Command, args []string) {
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
         content, err := rest.SendGet("executionzones/" + strconv.Itoa(id) + "/attributes/list")
         lib.HandleError(err)

--- a/zenboot-cli/cmd/listcustomers.go
+++ b/zenboot-cli/cmd/listcustomers.go
@@ -28,7 +28,7 @@ var listcustomersCmd = &cobra.Command{
 	Short: "list all customers",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		content, err := rest.SendGet("customers/list")
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/listcustomers.go
+++ b/zenboot-cli/cmd/listcustomers.go
@@ -13,10 +13,10 @@ type CustomersResponse struct {
 }
 
 type Customer struct {
-	Id              int      `json:"id"`
-    Email           string   `json:"email"`
-	CreationDate    string   `json:"creationDate"`
-	Hosts           []string `json:"hosts"`
+	Id           int      `json:"id"`
+	Email        string   `json:"email"`
+	CreationDate string   `json:"creationDate"`
+	Hosts        []string `json:"hosts"`
 }
 
 func init() {

--- a/zenboot-cli/cmd/listexectypes.go
+++ b/zenboot-cli/cmd/listexectypes.go
@@ -17,7 +17,7 @@ var listexectypesCmd = &cobra.Command{
 	Short: "list all exectypes",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		content, err := rest.SendGet("exectypes/list")
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/listhosts.go
+++ b/zenboot-cli/cmd/listhosts.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 
 	"../lib"
 	"github.com/hokaccha/go-prettyjson"
 	"github.com/spf13/cobra"
-	"strconv"
 )
 
 type HostsResponse struct {
@@ -20,7 +20,6 @@ type Host struct {
 	IPAdress    string   `json:"ipaddress"`
 	ServiceUrls []string `json:"serviceUrls"`
 }
-
 
 func init() {
 	listhostsCmd.Flags().IntVarP(&id, "executionzone", "e", 0, "Zone filter for hosts")

--- a/zenboot-cli/cmd/listhosts.go
+++ b/zenboot-cli/cmd/listhosts.go
@@ -32,7 +32,7 @@ var listhostsCmd = &cobra.Command{
 	Short: "list all CREATED and COMPLETED hosts [matching the given execution zone]",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		var filter string
 

--- a/zenboot-cli/cmd/listhoststates.go
+++ b/zenboot-cli/cmd/listhoststates.go
@@ -17,7 +17,7 @@ var listhoststatesCmd = &cobra.Command{
 	Short: "list all host states",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		content, err := rest.SendGet("hoststates")
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/listhoststates.go
+++ b/zenboot-cli/cmd/listhoststates.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
+
 	"../lib"
 	"github.com/hokaccha/go-prettyjson"
 	"github.com/spf13/cobra"
 )
-
 
 func init() {
 	listCmd.AddCommand(listhoststatesCmd)

--- a/zenboot-cli/cmd/listnotifications.go
+++ b/zenboot-cli/cmd/listnotifications.go
@@ -17,7 +17,7 @@ var listnotificationsCmd = &cobra.Command{
 	Short: "list all notifications",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		content, err := rest.SendGet("usernotifications/list")
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/listparams.go
+++ b/zenboot-cli/cmd/listparams.go
@@ -20,15 +20,15 @@ var listParametersCmd = &cobra.Command{
 		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 		var url = ""
 
-        if len(args) < 1 {
-		    url = "executionzones/" + strconv.Itoa(id) + "/params/list"
-        } else {
-            action, _ := lib.ValidateAction(args[0])
-		    url = "executionzones/" + strconv.Itoa(id) + "/actions/" + action + "/params/list"
-        }
+		if len(args) < 1 {
+			url = "executionzones/" + strconv.Itoa(id) + "/params/list"
+		} else {
+			action, _ := lib.ValidateAction(args[0])
+			url = "executionzones/" + strconv.Itoa(id) + "/actions/" + action + "/params/list"
+		}
 
-        content, err := rest.SendGet(url)
-        lib.HandleError(err)
+		content, err := rest.SendGet(url)
+		lib.HandleError(err)
 
 		prettyjson, _ := prettyjson.Format(content)
 		fmt.Println(string(prettyjson))

--- a/zenboot-cli/cmd/listparams.go
+++ b/zenboot-cli/cmd/listparams.go
@@ -17,8 +17,8 @@ var listParametersCmd = &cobra.Command{
 	Use:   "parameters [flags] [action]",
 	Short: "list all required parameters of an Execution Zone or one of its actions",
 	Run: func(cmd *cobra.Command, args []string) {
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
-        var url = ""
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
+		var url = ""
 
         if len(args) < 1 {
 		    url = "executionzones/" + strconv.Itoa(id) + "/params/list"

--- a/zenboot-cli/cmd/listserviceurls.go
+++ b/zenboot-cli/cmd/listserviceurls.go
@@ -17,7 +17,7 @@ var listserviceurlsCmd = &cobra.Command{
 	Short: "list all serviceurls",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		content, err := rest.SendGet("serviceurls/list")
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/listzones.go
+++ b/zenboot-cli/cmd/listzones.go
@@ -34,7 +34,7 @@ var listzonesCmd = &cobra.Command{
 	Short: "list all Execution Zones [matching the given arguments]",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret}
+		var rest = lib.Zenboot{ZenbootUrl: zenbootUrl, Username: username, Secret: secret, Ignore: ignore}
 
 		content, err := rest.SendGet("executionzones/list")
 		lib.HandleError(err)

--- a/zenboot-cli/cmd/listzones.go
+++ b/zenboot-cli/cmd/listzones.go
@@ -45,8 +45,8 @@ var listzonesCmd = &cobra.Command{
 		filteredZones := ExecutionZonesResponse{}
 		if domain != "" || zoneType != "" {
 			for _, executionZone := range jsonZones.ExecutionZones {
-				if strings.Contains(executionZone.ExecDescription, domain) && strings.Contains(executionZone.ExecType, zoneType){
-						filteredZones.ExecutionZones = append(filteredZones.ExecutionZones, executionZone)
+				if strings.Contains(executionZone.ExecDescription, domain) && strings.Contains(executionZone.ExecType, zoneType) {
+					filteredZones.ExecutionZones = append(filteredZones.ExecutionZones, executionZone)
 				}
 			}
 		} else {

--- a/zenboot-cli/cmd/root.go
+++ b/zenboot-cli/cmd/root.go
@@ -13,6 +13,7 @@ var cfgFile string
 var username string
 var secret string
 var zenbootUrl string
+var ignore []string
 var id int
 var default_zenbootUrl string = "https://zenboot.hybris.com"
 
@@ -31,6 +32,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&zenbootUrl, "zenbooturl", "z", "", "The zenboot instance to use (default is https://zenboot.hybris.com)")
 	RootCmd.PersistentFlags().StringVarP(&username, "username", "u", "", "The username to connect to zenboot (default is empty)")
 	RootCmd.PersistentFlags().StringVarP(&secret, "secret", "s", "", "The password to connect (default is empty)")
+	RootCmd.PersistentFlags().StringSliceVarP(&ignore, "ignore", "i", []string{""}, "Ignore a list of non-fatal errors (currently only 'cert')")
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.zenboot.json)")
 	RootCmd.PersistentFlags().IntVarP(&id, "executionzone", "e", 0, "the id of the Execution Zone in which to execute.")
 	initConfig()


### PR DESCRIPTION
Add an extra 'ignore' field to the zenboot type which allows the specification of a list of error messages to be ignored by zenboot upon http call executions. In this iteration only add 'cert' (standing for certificate) for now, which will disable certificate validation.