### PR TITLE
Allow non-admin users to use all rest services (fix 403 problem)

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -176,7 +176,15 @@ grails.plugin.springsecurity.controllerAnnotations.staticRules = [
     '/host/show':                           ['IS_AUTHENTICATED_REMEMBERED'],
     '/serviceUrl/show':                     ['IS_AUTHENTICATED_REMEMBERED'],
     '/executionZone/ajaxGetReadme':         ['IS_AUTHENTICATED_REMEMBERED'],
+
+	// internal calls
     '/executionZoneRest/**':                ['IS_AUTHENTICATED_REMEMBERED'],
+    '/executionZoneActionRest/**':          ['IS_AUTHENTICATED_REMEMBERED'],
+    '/serviceUrlRest/**':                   ['IS_AUTHENTICATED_REMEMBERED'],
+    '/hostRest/**':                         ['IS_AUTHENTICATED_REMEMBERED'],
+    '/customerRest/**':                     ['IS_AUTHENTICATED_REMEMBERED'],
+    '/userNotificationRest/**':             ['IS_AUTHENTICATED_REMEMBERED'],
+    '/executionZoneTypeRest/**':            ['IS_AUTHENTICATED_REMEMBERED'],
   
     //default
     '/administration':                      [Role.ROLE_ADMIN],

--- a/grails-app/controllers/org/zenboot/portal/processing/HostRestController.groovy
+++ b/grails-app/controllers/org/zenboot/portal/processing/HostRestController.groovy
@@ -42,11 +42,10 @@ class HostRestController extends AbstractRestController {
             def currentUserID = springSecurityService.getCurrentUserId()
 
             if (accessService.accessCache[currentUserID]) {
-                usersExecutionZones = accessService.accessCache[currentUserID].findAll {it.value}
-            }
-            else {
+                usersExecutionZones = accessService.accessCache[currentUserID].findAll {it.value}.collect {it.key}
+            } else {
                 accessService.refreshAccessCacheByUser(Person.findById(currentUserID))
-                usersExecutionZones = accessService.accessCache[currentUserID].findAll {it.value}
+                usersExecutionZones = accessService.accessCache[currentUserID].findAll {it.value}.collect {it.key}
             }
 
             if (usersExecutionZones.isEmpty()) {


### PR DESCRIPTION
Spring security is configured to allow accessing REST services (URLs).
Application for these REST calls makes internal calls to controllers. Unfortunately,
Spring security configuration didn't allow non-admin users to access them.
See ('/**': [Role.ROLE_ADMIN]). Internal calls are executed with the current
user rights, so mappings must be added to controllerAnnotations.staticRules.