### PR TITLE
remove azure-cli and update to newest binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: groovy
-jdk: oraclejdk8
+jdk: openjdk8
 env: GO_VERSION=1.9 GOROOT="/usr/lib/go-1.9" GOPATH="${TRAVIS_BUILD_DIR}/.go" PATH="/usr/lib/go-1.9/bin:${PATH}"
 before_install:
 - sudo add-apt-repository -y ppa:gophers/archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,14 +75,6 @@ RUN apt-get update && apt-get install -y docker-ce
 RUN curl -o /usr/local/bin/kubectl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.0/bin/linux/amd64/kubectl \
       && chmod +x /usr/local/bin/kubectl
 
-# install Azure-cli
-# workaround for https://github.com/Azure/azure-cli/issues/3863
-RUN wget ftp.de.debian.org/debian/pool/main/o/openssl/libssl1.0.0_1.0.2l-1~bpo8+1_amd64.deb && dpkg -i libssl1.0.0_1.0.2l-1~bpo8+1_amd64.deb
-RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" | \
-     sudo tee /etc/apt/sources.list.d/azure-cli.list
-RUN apt-key adv --keyserver packages.microsoft.com --recv-keys EB3E94ADBE1229CF
-RUN apt-get update && apt-get install azure-cli
-
 USER user
 
 ARG VERSION


### PR DESCRIPTION
The docker image no longer can be built with the azure-cli as part of it. Since the breaking part was only a workaround and the azure-cli isn't actually needed, it was removed.